### PR TITLE
Scope and standardize AGENTS validation checklists

### DIFF
--- a/AGENTS/00-general/VALIDATION.md
+++ b/AGENTS/00-general/VALIDATION.md
@@ -1,10 +1,12 @@
-- All modified files are inside the intended package.
-- The `core` package was not modified.
-- No unrelated files were changed.
-- Naming conventions match nearby files.
-- Namespaces match paths.
-- PHP syntax is valid.
-- JSON syntax is valid.
-- Existing package conventions were followed.
-- No obsolete or duplicate logic was introduced.
-- The change is understandable for a human reviewer.
+# Validation checklist — General (all tasks)
+
+- [ ] All modified files are within the intended package scope.
+- [ ] The `core` package was not modified.
+- [ ] No unrelated files were changed.
+- [ ] Naming conventions match nearby package files.
+- [ ] Namespaces and paths are consistent.
+- [ ] PHP syntax is valid for all touched PHP files.
+- [ ] JSON syntax is valid for all touched JSON files.
+- [ ] Existing package conventions were followed.
+- [ ] No obsolete or duplicate logic was introduced.
+- [ ] The change is understandable and reviewable by a human developer.

--- a/AGENTS/10-create-entity/VALIDATION.md
+++ b/AGENTS/10-create-entity/VALIDATION.md
@@ -1,13 +1,14 @@
-- The entity class exists at the expected path.
-- The namespace matches the file path.
-- The class name matches the file name.
-- The entity follows ORM conventions.
-- All fields have valid definitions.
-- Relation targets exist.
-- Computed fields have valid dependencies.
-- Required form/list views exist when needed.
-- Views reference only existing fields.
-- Translation files exist for all supported languages.
-- All fields are translated with `label`, `description`, and `help`.
-- View names and section IDs are translated.
-- No unrelated entity was modified.
+# Validation checklist — Create entity
+
+- [ ] The new entity class was created at the expected ORM path for the target package.
+- [ ] The namespace matches the file path and the class name matches the file name.
+- [ ] Entity metadata/configuration follows package ORM conventions.
+- [ ] Every declared field has a valid type and coherent options.
+- [ ] Relation fields target existing entities and valid target fields.
+- [ ] Computed/derived fields declare complete and valid dependencies.
+- [ ] Required default form and/or list views were created when the entity is user-facing.
+- [ ] Newly created views reference only existing fields.
+- [ ] Translation files were created or updated for all supported languages.
+- [ ] Field translations include `label`, `description`, and `help` where required.
+- [ ] View names and section identifiers introduced by this entity are translated.
+- [ ] No unrelated entity definition was modified.

--- a/AGENTS/20-update-field/VALIDATION.md
+++ b/AGENTS/20-update-field/VALIDATION.md
@@ -1,12 +1,14 @@
-- The field exists in the intended entity class.
-- The field type and properties are valid.
-- Relations reference valid objects and fields.
-- Computed field dependencies are complete.
-- All view references are valid.
-- Form views were updated when user-facing input is required.
-- List views were updated when the field must be visible in lists.
-- Filters, actions, data providers, and exports were checked.
-- Translation entries exist in every supported language.
-- Each impacted field has `label`, `description`, and `help`.
-- Removed or renamed fields have no stale references.
-- No unrelated field was modified.
+# Validation checklist — Update field
+
+- [ ] The field exists (or is intentionally introduced/removed) in the intended entity.
+- [ ] The field type and options are valid for the business intent.
+- [ ] Relation updates point to existing entities/fields and preserve consistency.
+- [ ] Computed/derived field dependencies were updated and remain complete.
+- [ ] All impacted view references (form/list/search/filter) are valid.
+- [ ] Form views were updated when the field affects data entry.
+- [ ] List views were updated when the field affects table visibility or sorting.
+- [ ] Related filters, actions, data providers, exports, and routes were reviewed.
+- [ ] Translation entries were updated in every supported language.
+- [ ] Impacted field translations include `label`, `description`, and `help`.
+- [ ] Removed/renamed fields no longer have stale references in code, views, or i18n.
+- [ ] No unrelated field changes were introduced in the same entity/package.

--- a/AGENTS/30-create-or-update-view/VALIDATION.md
+++ b/AGENTS/30-create-or-update-view/VALIDATION.md
@@ -1,12 +1,13 @@
-- The view file path follows package conventions.
-- The view name follows package conventions.
-- JSON syntax is valid.
-- The referenced entity exists.
-- Every referenced field exists in the ORM class.
-- Form layout structure is valid.
-- List layout structure is valid.
-- Section IDs are translated.
-- View names are translated.
-- View actions reference valid actions.
-- Routes, exports, and filters are valid.
-- No obsolete fields remain in the view.
+# Validation checklist — Create or update view
+
+- [ ] The view file path and naming follow package conventions.
+- [ ] JSON syntax is valid and the document structure matches expected schema.
+- [ ] The referenced entity exists and matches the intended business object.
+- [ ] Every referenced field exists in the corresponding ORM/entity class.
+- [ ] Form layout structure (sections, groups, widgets) is valid and coherent.
+- [ ] List layout structure (columns, sort/filter config) is valid and coherent.
+- [ ] Referenced actions/data providers/routes/exports exist and are compatible.
+- [ ] View labels/titles are translated in supported languages.
+- [ ] Section identifiers used in the view are translated.
+- [ ] No obsolete fields or stale action references remain in the updated view.
+- [ ] No unrelated views were modified.

--- a/AGENTS/40-update-translations/VALIDATION.md
+++ b/AGENTS/40-update-translations/VALIDATION.md
@@ -1,13 +1,14 @@
-- [ ] All supported languages were updated.
-- [ ] Translation files follow the entity namespace path.
-- [ ] Root keys are present.
-- [ ] Every impacted field has `label`, `description`, and `help`.
-- [ ] Selection values are translated.
-- [ ] View names are translated.
-- [ ] View descriptions are present when required.
-- [ ] Section IDs used in views are translated.
-- [ ] Actions referenced in views are translated.
-- [ ] Routes and exports are translated when present.
-- [ ] Business errors are translated.
-- [ ] No obsolete field or view translation remains after renaming or deletion.
-- [ ] JSON syntax is valid.
+# Validation checklist — Update translations
+
+- [ ] All supported language files impacted by the task were updated.
+- [ ] Translation file paths follow the expected entity/package namespace structure.
+- [ ] Required root keys and intermediate objects are present.
+- [ ] Every impacted field has `label`, `description`, and `help` when required.
+- [ ] Added/updated selection values are translated consistently across languages.
+- [ ] Impacted view names/titles are translated.
+- [ ] Impacted view descriptions are present when required by conventions.
+- [ ] Section identifiers used by impacted views are translated.
+- [ ] Referenced actions/data providers/routes/exports include required translations.
+- [ ] Business errors/messages introduced or modified are translated.
+- [ ] Obsolete translations were removed after field/view/action rename or deletion.
+- [ ] JSON syntax is valid in every touched translation file.

--- a/AGENTS/50-create-action-handler/VALIDATION.md
+++ b/AGENTS/50-create-action-handler/VALIDATION.md
@@ -1,10 +1,13 @@
-- The file is in the correct `actions/` or `data/` path.
-- The linked entity exists.
-- Parameters are validated.
-- Return structure is explicit and consistent with package conventions.
-- Business errors are explicit.
-- Business errors are translated.
-- View references to the action are valid.
-- Action labels and descriptions are translated.
-- No duplicate business logic was introduced.
-- No unrelated action or data handler was modified.
+# Validation checklist — Create action handler
+
+- [ ] The handler file is located in the correct `actions/` path.
+- [ ] The linked entity/business object exists and is correctly referenced.
+- [ ] Input parameters are explicitly validated (presence, type, constraints).
+- [ ] Authorization/security expectations are respected for the action context.
+- [ ] Return payload structure is explicit and consistent with package conventions.
+- [ ] Business errors are explicit, deterministic, and mapped to clear conditions.
+- [ ] Business errors/messages are translated in supported languages.
+- [ ] Any view/button/menu reference to this action is valid.
+- [ ] Action label/description translations are present where required.
+- [ ] No duplicate logic was added when reusable services already exist.
+- [ ] No unrelated action or data-provider files were modified.

--- a/AGENTS/60-create-data-provider/VALIDATION.md
+++ b/AGENTS/60-create-data-provider/VALIDATION.md
@@ -1,10 +1,13 @@
-- The file is in the correct `data/` path.
-- The linked entity exists.
-- Parameters are validated.
-- Return structure is explicit and consistent with package conventions.
-- Business errors are explicit.
-- Business errors are translated.
-- View references to the action are valid.
-- Action labels and descriptions are translated.
-- No duplicate business logic was introduced.
-- No unrelated action or data handler was modified.
+# Validation checklist — Create data provider
+
+- [ ] The provider file is located in the correct `data/` path.
+- [ ] The linked entity/business object exists and is correctly referenced.
+- [ ] Input parameters are explicitly validated (presence, type, constraints).
+- [ ] Query/filter/scope logic is deterministic and aligned with business rules.
+- [ ] Returned data structure is explicit and consistent with consumer expectations.
+- [ ] Error cases are explicit and use package-convention error structures.
+- [ ] Provider-related messages/errors are translated when user-visible.
+- [ ] Any view/filter/action using this provider references it correctly.
+- [ ] Provider label/description translations are present where required.
+- [ ] No duplicate retrieval logic was added when reusable providers exist.
+- [ ] No unrelated actions or other data providers were modified.

--- a/AGENTS/90-final-validation/VALIDATION.md
+++ b/AGENTS/90-final-validation/VALIDATION.md
@@ -1,14 +1,16 @@
-- All modified files are inside the intended package.
-- The `core` package was not modified.
-- PHP syntax is valid.
-- JSON syntax is valid.
-- Namespaces match file paths.
-- Entity fields referenced in views exist.
-- Translations exist for all impacted languages.
-- Form section IDs are translated.
-- Actions referenced in views exist.
-- Action labels and errors are translated.
-- Obsolete field/view/i18n references were removed.
-- No unnecessary unrelated changes were made.
-- Existing package conventions were followed.
-- The final change can be reviewed by a human developer.
+# Validation checklist — Final cross-layer review
+
+- [ ] All modified files are inside the intended package.
+- [ ] The `core` package was not modified.
+- [ ] PHP syntax is valid.
+- [ ] JSON syntax is valid.
+- [ ] Namespaces match file paths.
+- [ ] Every entity field referenced in impacted views exists.
+- [ ] Translations exist for every impacted supported language.
+- [ ] Form/list section identifiers used in views are translated.
+- [ ] Actions and data providers referenced in views exist.
+- [ ] Action/provider labels and user-visible errors are translated.
+- [ ] Obsolete field/view/i18n references were removed.
+- [ ] No unnecessary unrelated changes were introduced.
+- [ ] Existing package conventions were respected.
+- [ ] The final diff is coherent and reviewable end-to-end.


### PR DESCRIPTION
### Motivation
- Make each `AGENTS/*/VALIDATION.md` checklist explicitly scoped to the task indicated by its parent folder to reduce ambiguity during agent validation. 
- Standardize the checklist format to improve consistency and make validation steps actionable for reviewers. 
- Add task-specific checks (for example security/authorization for actions and deterministic query/return expectations for data providers) to better capture domain concerns.

### Description
- Rewrote and standardized the validation files for all task folders by replacing free-form lists with titled checklists and actionable `- [ ]` items. 
- Updated these eight files: `AGENTS/00-general/VALIDATION.md`, `AGENTS/10-create-entity/VALIDATION.md`, `AGENTS/20-update-field/VALIDATION.md`, `AGENTS/30-create-or-update-view/VALIDATION.md`, `AGENTS/40-update-translations/VALIDATION.md`, `AGENTS/50-create-action-handler/VALIDATION.md`, `AGENTS/60-create-data-provider/VALIDATION.md`, and `AGENTS/90-final-validation/VALIDATION.md`. 
- Introduced clearer, task-specific requirements such as parameter/authorization checks for action handlers and query determinism and consumer contract checks for data providers. 
- Ensured translation, JSON/PHP syntax, and package/core constraints remain explicit across the general and final cross-layer checklists. 

### Testing
- Confirmed the eight `AGENTS/*/VALIDATION.md` files were updated and inspected their contents to verify the new titled checklists and checklist items are present. 
- Verified repository shows the intended changes and that the updates are recorded in the repository history. 
- Printed and reviewed the updated files with line numbers to ensure formatting and checklist completeness; all validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f74a2458008325b6c0079995de3167)